### PR TITLE
fix: get lastState in case of using data_generator with "future" values

### DIFF
--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -111,7 +111,7 @@ export default class GraphEntry {
   }
 
   get lastState(): number | null {
-    return this.history.length > 0 ? this.history[this.history.length - 1][1] : null;
+    return (this._entityState != undefined && this._entityState.state != undefined) ? Number(this._entityState.state) : null;
   }
 
   public nowValue(now: number, before: boolean): number | null {


### PR DESCRIPTION
when using a data_generator, the current state is in-correctly reflected by always using the last/"youngest" historical value instead of the current state of the entity

fixes(#8)