### PR TITLE
Fix getlast state

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RomRider/apexcharts-card.git"
+    "url": "git+https://github.com/TheBrain8791/apexcharts-card.git"
+                
   },
   "keywords": [
     "lovelace",
@@ -25,9 +26,9 @@
   "author": "Jérôme Wiedemann",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/RomRider/apexcharts-card/issues"
+    "url": "https://github.com/TheBrain8791/apexcharts-card.git/issues"
   },
-  "homepage": "https://github.com/RomRider/apexcharts-card#readme",
+  "homepage": "https://github.com/TheBrain8791/apexcharts-card.git#readme",
   "dependencies": {
     "@ctrl/tinycolor": "^3.4.0",
     "@material/mwc-ripple": "^0.25.3",

--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -111,7 +111,7 @@ export default class GraphEntry {
   }
 
   get lastState(): number | null {
-    return this.history.length > 0 ? this.history[this.history.length - 1][1] : null;
+    return (this._entityState != undefined && this._entityState.state != undefined) ? Number(this._entityState.state) : null;
   }
 
   public nowValue(now: number, before: boolean): number | null {


### PR DESCRIPTION
when using a data_generator, the current state is in-correctly reflected by always using the last/"youngest" historical value instead of the current state of the entity

fixes https://github.com/TheBrain8791/apexcharts-card/issues/8